### PR TITLE
Add check that the X-Request-Id header is passed to the writer.

### DIFF
--- a/native/native_writer_test.go
+++ b/native/native_writer_test.go
@@ -39,6 +39,7 @@ func setupMockNativeWriterService(t *testing.T, status int, hasHash bool) *httpt
 		assert.Equal(t, "PUT", req.Method)
 		assert.Equal(t, "/"+methodeCollection+"/"+aUUID, req.URL.Path)
 		assert.Equal(t, nativeRWHostHeader, req.Host)
+		assert.Equal(t, publishRef, req.Header.Get(transactionIDHeader))
 		if hasHash {
 			assert.Equal(t, aHash, req.Header.Get(nativeHashHeader))
 		}


### PR DESCRIPTION
Not a bug fix as such, but just an addition to the tests, to confirm that the header value is specified correctly.