### PR TITLE
Feature/uppsf 1164 patch publishing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea/
+.vscode/
 /native-ingester*
 /.project
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,21 @@ Example command line:
 native-ingester --read-queue-addresses localhost:2181 --read-queue-group nativeIngesterCms --read-queue-topic PreNativeCmsPublicationEvents --native-writer-address http://localhost:8081 --content-uuid-fields uuid --content-uuid-fields post.uuid --content-uuid-fields data.uuidv3 --content-uuid-fields id --write-queue-address localhost:9092 --write-topic NativeCmsPublicationEvents --config config.json --content-type Content --panic-guide https://runbooks.in.ft.com/native-ingester
 ``` 
 
+If you want to run it with docker-compose and all the services native-ingester depends on, first you need to build them with `local` tag.
+
+Prepare `cms-notifier:local` and `nativerw:local` and then run:
+
+```sh
+docker-compose up
+```
+
+| Service         | Port |
+|-----------------|------|
+| native-ingester | 8080 |
+| cms-notifier    | 8081 |
+| nativerw        | 8083 |
+
+
 ## Admin endpoints
 
   - `https://{host}/__native-store-{type}/__health`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,13 +3,11 @@ version: '3'
 services:
   zookeeper:
     image: wurstmeister/zookeeper
-    container_name: zookeeper
     ports:
       - "2181:2181"
 
   kafka:
     image: wurstmeister/kafka:0.8.2.0
-    container_name: kafka
     ports:
       - "9092:9092"
     environment:
@@ -23,8 +21,7 @@ services:
       - zookeeper
 
   cms-notifier:
-    image: nexus.in.ft.com:5000/coco/cms-notifier
-    container_name: cms-notifier
+    image: cms-notifier:local
     environment:
       KAFKA_HOST: kafka
       KAFKA_PORT: 9092
@@ -38,18 +35,36 @@ services:
     depends_on:
       - kafka
 
+  mongo:
+    image: mongo:3.4.17
+    ports:
+      - "27017:27017"
+
+  nativerw:
+    image: nativerw:local
+    environment:
+      MONGOS: mongo:27017
+      MONGO_NODE_COUNT: 1
+      CONFIG: /configs/config.json
+    ports:
+      - "8083:8080"
+      - "8084:8081"
+    depends_on:
+      - mongo
+
   app:
     build: .
     image: native-ingester:local
-    container_name: native-ingester
     environment:
       NATIVE_CONTENT_UUID_FIELDS: "uuid,post.uuid,data.uuidv3,id"
+      NATIVE_RW_ADDRESS: "http://nativerw:8080"
       CONFIG: "config.json"
       Q_READ_GROUP: "nativeIngesterCms"
       Q_READ_ADDR: "zookeeper:2181"
       Q_READ_TOPIC: "PreNativeCmsPublicationEvents"
       Q_WRITE_ADDR: "kafka:9092"
       Q_WRITE_TOPIC: "NativeCmsPublicationEvents"
+      PANIC_GUIDE_URL: "http://example.com/panicguide"
     ports:
       - "8080:8080"
     depends_on:

--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -50,9 +50,9 @@ func (w *WriterMock) GetCollection(originID string, contentType string) (string,
 	return args.String(0), args.Error(1)
 }
 
-func (w *WriterMock) WriteToCollection(msg native.NativeMessage, collection string) (string, error) {
+func (w *WriterMock) WriteToCollection(msg native.NativeMessage, collection string) (string, string, error) {
 	args := w.Called(msg, collection)
-	return args.String(0), args.Error(1)
+	return args.String(0), args.String(1), args.Error(2)
 }
 
 func (w *WriterMock) ConnectivityCheck() (string, error) {

--- a/native/native_writer_test.go
+++ b/native/native_writer_test.go
@@ -14,21 +14,22 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
-var methodeCollection = []string{"methode"}
-
 const (
-	methodeOriginSystemID   = "http://cmdb.ft.com/systems/methode-web-pub"
-	publishRef              = "tid_test-pub-ref"
-	aUUID                   = "572d0acc-3f12-4e70-8830-8092c1042a52"
-	aTimestamp              = "2017-02-16T12:56:16Z"
-	aHash                   = "27f79e6d884acdd642d1758c4fd30d43074f8384d552d1ebb1959345"
-	aContentType            = "application/json; version=1.0"
-	withNativeHashHeader    = true
-	withoutNativeHashHeader = false
+	methodeOriginSystemID       = "http://cmdb.ft.com/systems/methode-web-pub"
+	publishRef                  = "tid_test-pub-ref"
+	aUUID                       = "572d0acc-3f12-4e70-8830-8092c1042a52"
+	aTimestamp                  = "2017-02-16T12:56:16Z"
+	aHash                       = "27f79e6d884acdd642d1758c4fd30d43074f8384d552d1ebb1959345"
+	aContentType                = "application/json; version=1.0"
+	withNativeHashHeader        = true
+	withoutNativeHashHeader     = false
+	messageTypeContentPublished = "cms-content-published"
+	methodeCollectionName       = "methode"
 )
 
 var strCollectionsOriginIdsMap string
 var audioStrCollectionsOriginIdsMap string
+var sparkCollectionsOriginIdsMap string
 var aContentBody map[string]interface{}
 
 func init() {
@@ -50,6 +51,15 @@ func init() {
 			   }
 		   ]
    }`
+	sparkCollectionsOriginIdsMap =
+		`{
+			"http://cmdb.ft.com/systems/spark": [
+				{
+					"content_type": ".*",
+					"collection": "universal-content"
+				}
+			]
+   }`
 	strCollectionsOriginIdsMap = `{
 		"http://cmdb.ft.com/systems/methode-web-pub": [
 			{
@@ -60,13 +70,13 @@ func init() {
 	}`
 }
 
-func setupMockNativeWriterService(t *testing.T, status int, hasHash bool) *httptest.Server {
+func setupMockNativeWriterService(t *testing.T, status int, hasHash bool, method string, collection string) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		if status != 200 {
 			w.WriteHeader(status)
 		}
-		assert.Equal(t, "PUT", req.Method)
-		assert.Equal(t, "/"+methodeCollection[0]+"/"+aUUID, req.URL.Path)
+		assert.Equal(t, method, req.Method)
+		assert.Equal(t, "/"+collection+"/"+aUUID, req.URL.Path)
 		assert.Equal(t, publishRef, req.Header.Get(transactionIDHeader))
 		assert.Equal(t, aContentType, req.Header.Get(contentTypeHeader))
 		if hasHash {
@@ -99,7 +109,7 @@ func TestGetCollectionShort(t *testing.T) {
 
 	actualCollection, err := w.GetCollection(methodeOriginSystemID, aContentType)
 	assert.NoError(t, err, "It should not return an error")
-	assert.Equal(t, methodeCollection[0], actualCollection, "It should return the methode collection")
+	assert.Equal(t, methodeCollectionName, actualCollection, "It should return the methode collection")
 
 	_, err = w.GetCollection("Origin-Id-that-do-not-exist", aContentType)
 	assert.EqualError(t, err, "origin system not found", "It should return a collection not found error")
@@ -257,17 +267,57 @@ func TestWriteMessageToCollectionWithSuccess(t *testing.T) {
 	testCollectionsOriginIdsMap, err := getConfig(strCollectionsOriginIdsMap)
 	assert.NoError(t, err, "It should not return an error")
 	p.On("getUUID", aContentBody).Return(aUUID, nil)
-	nws := setupMockNativeWriterService(t, 200, withoutNativeHashHeader)
+	nws := setupMockNativeWriterService(t, 200, withoutNativeHashHeader, "PUT", methodeCollectionName)
 	defer nws.Close()
 
-	msg, err := NewNativeMessage("{}", aTimestamp, publishRef, messageTypePartial)
+	msg, err := NewNativeMessage("{}", aTimestamp, publishRef, messageTypeContentPublished)
 	msg.AddContentTypeHeader(aContentType)
 	assert.NoError(t, err, "It should not return an error by creating a message")
 
 	w := NewWriter(nws.URL, *testCollectionsOriginIdsMap, p)
-	contentUUID, _, err := w.WriteToCollection(msg, methodeCollection[0])
+	contentUUID, _, err := w.WriteToCollection(msg, methodeCollectionName)
 
 	assert.NoError(t, err, "It should not return an error")
+	assert.Equal(t, aUUID, contentUUID)
+	p.AssertExpectations(t)
+}
+
+func TestWritePartialMessageToCollectionWithSuccess(t *testing.T) {
+	p := new(ContentBodyParserMock)
+	testCollectionsOriginIdsMap, err := getConfig(sparkCollectionsOriginIdsMap)
+	assert.NoError(t, err, "It should not return an error")
+	p.On("getUUID", aContentBody).Return(aUUID, nil)
+	nws := setupMockNativeWriterService(t, 200, withoutNativeHashHeader, "PATCH", universalContentCollectionName)
+	defer nws.Close()
+
+	msg, err := NewNativeMessage("{}", aTimestamp, publishRef, messageTypePartialContentPublished)
+	msg.AddContentTypeHeader(aContentType)
+	assert.NoError(t, err, "It should not return an error by creating a message")
+
+	w := NewWriter(nws.URL, *testCollectionsOriginIdsMap, p)
+	contentUUID, _, err := w.WriteToCollection(msg, universalContentCollectionName)
+
+	assert.NoError(t, err, "It should not return an error")
+	assert.Equal(t, aUUID, contentUUID)
+	p.AssertExpectations(t)
+}
+
+func TestWritePartialMessageToCollectionFailBecauseOfUnsupportedCollection(t *testing.T) {
+	p := new(ContentBodyParserMock)
+	testCollectionsOriginIdsMap, err := getConfig(sparkCollectionsOriginIdsMap)
+	assert.NoError(t, err, "It should not return an error")
+	p.On("getUUID", aContentBody).Return(aUUID, nil)
+	nws := setupMockNativeWriterService(t, 200, withoutNativeHashHeader, "PATCH", universalContentCollectionName)
+	defer nws.Close()
+
+	msg, err := NewNativeMessage("{}", aTimestamp, publishRef, messageTypePartialContentPublished)
+	msg.AddContentTypeHeader(aContentType)
+	assert.NoError(t, err, "It should not return an error by creating a message")
+
+	w := NewWriter(nws.URL, *testCollectionsOriginIdsMap, p)
+	contentUUID, _, err := w.WriteToCollection(msg, methodeCollectionName)
+
+	assert.EqualError(t, err, "Error calling PATCH endoint - only supported for universal-content collection", "It should return an error")
 	assert.Equal(t, aUUID, contentUUID)
 	p.AssertExpectations(t)
 }
@@ -278,16 +328,16 @@ func TestWriteMessageWithHashToCollectionWithSuccess(t *testing.T) {
 	assert.NoError(t, err, "It should not return an error")
 
 	p.On("getUUID", aContentBody).Return(aUUID, nil)
-	nws := setupMockNativeWriterService(t, 200, withNativeHashHeader)
+	nws := setupMockNativeWriterService(t, 200, withNativeHashHeader, "PUT", methodeCollectionName)
 	defer nws.Close()
 
-	msg, err := NewNativeMessage("{}", aTimestamp, publishRef, messageTypePartial)
+	msg, err := NewNativeMessage("{}", aTimestamp, publishRef, messageTypeContentPublished)
 	assert.NoError(t, err, "It should not return an error by creating a message")
 	msg.AddHashHeader(aHash)
 	msg.AddContentTypeHeader(aContentType)
 
 	w := NewWriter(nws.URL, *testCollectionsOriginIdsMap, p)
-	contentUUID, _, err := w.WriteToCollection(msg, methodeCollection[0])
+	contentUUID, _, err := w.WriteToCollection(msg, methodeCollectionName)
 
 	assert.NoError(t, err, "It should not return an error")
 	assert.Equal(t, aUUID, contentUUID)
@@ -300,16 +350,16 @@ func TestWriteMessageToCollectionWithContentTypeSuccess(t *testing.T) {
 	assert.NoError(t, err, "It should not return an error")
 
 	p.On("getUUID", aContentBody).Return(aUUID, nil)
-	nws := setupMockNativeWriterService(t, 200, withNativeHashHeader)
+	nws := setupMockNativeWriterService(t, 200, withNativeHashHeader, "PUT", methodeCollectionName)
 	defer nws.Close()
 
-	msg, err := NewNativeMessage("{}", aTimestamp, publishRef, messageTypePartial)
+	msg, err := NewNativeMessage("{}", aTimestamp, publishRef, messageTypeContentPublished)
 	assert.NoError(t, err, "It should not return an error by creating a message")
 	msg.AddHashHeader(aHash)
 	msg.AddContentTypeHeader(aContentType)
 
 	w := NewWriter(nws.URL, *testCollectionsOriginIdsMap, p)
-	contentUUID, _, err := w.WriteToCollection(msg, methodeCollection[0])
+	contentUUID, _, err := w.WriteToCollection(msg, methodeCollectionName)
 
 	assert.NoError(t, err, "It should not return an error")
 	assert.Equal(t, aUUID, contentUUID)
@@ -322,15 +372,15 @@ func TestWriteContentBodyToCollectionFailBecauseOfMissingUUID(t *testing.T) {
 	assert.NoError(t, err, "It should not return an error")
 
 	p.On("getUUID", aContentBody).Return("", errors.New("UUID not found"))
-	nws := setupMockNativeWriterService(t, 200, withNativeHashHeader)
+	nws := setupMockNativeWriterService(t, 200, withNativeHashHeader, "PUT", methodeCollectionName)
 	defer nws.Close()
 
-	msg, err := NewNativeMessage("{}", aTimestamp, publishRef, messageTypePartial)
+	msg, err := NewNativeMessage("{}", aTimestamp, publishRef, messageTypeContentPublished)
 	assert.NoError(t, err, "It should not return an error by creating a message")
 	msg.AddHashHeader(aHash)
 
 	w := NewWriter(nws.URL, *testCollectionsOriginIdsMap, p)
-	_, _, err = w.WriteToCollection(msg, methodeCollection[0])
+	_, _, err = w.WriteToCollection(msg, methodeCollectionName)
 
 	assert.EqualError(t, err, "UUID not found", "It should return a  UUID not found error")
 	p.AssertExpectations(t)
@@ -342,16 +392,16 @@ func TestWriteContentBodyToCollectionFailBecauseOfNativeRWServiceInternalError(t
 	assert.NoError(t, err, "It should not return an error")
 
 	p.On("getUUID", aContentBody).Return(aUUID, nil)
-	nws := setupMockNativeWriterService(t, 500, withoutNativeHashHeader)
+	nws := setupMockNativeWriterService(t, 500, withoutNativeHashHeader, "PUT", methodeCollectionName)
 	defer nws.Close()
 
-	msg, err := NewNativeMessage("{}", aTimestamp, publishRef, messageTypePartial)
+	msg, err := NewNativeMessage("{}", aTimestamp, publishRef, messageTypeContentPublished)
 	assert.NoError(t, err, "It should not return an error by creating a message")
 	msg.AddHashHeader(aHash)
 	msg.AddContentTypeHeader(aContentType)
 
 	w := NewWriter(nws.URL, *testCollectionsOriginIdsMap, p)
-	_, _, err = w.WriteToCollection(msg, methodeCollection[0])
+	_, _, err = w.WriteToCollection(msg, methodeCollectionName)
 
 	assert.EqualError(t, err, "Native writer returned non-200 code", "It should return a non-200 HTTP status error")
 	p.AssertExpectations(t)
@@ -364,13 +414,13 @@ func TestWriteContentBodyToCollectionFailBecauseOfNativeRWServiceNotAvailable(t 
 
 	p.On("getUUID", aContentBody).Return(aUUID, nil)
 
-	msg, err := NewNativeMessage("{}", aTimestamp, publishRef, messageTypePartial)
+	msg, err := NewNativeMessage("{}", aTimestamp, publishRef, messageTypeContentPublished)
 	assert.NoError(t, err, "It should not return an error by creating a message")
 	msg.AddHashHeader(aHash)
 	msg.AddContentTypeHeader(aContentType)
 
 	w := NewWriter("http://an-address.com", *testCollectionsOriginIdsMap, p)
-	_, _, err = w.WriteToCollection(msg, methodeCollection[0])
+	_, _, err = w.WriteToCollection(msg, methodeCollectionName)
 
 	assert.Error(t, err, "It should return an error")
 	p.AssertExpectations(t)
@@ -452,7 +502,7 @@ func (p *ContentBodyParserMock) getUUID(body map[string]interface{}) (string, er
 }
 
 func TestBuildNativeMessageSuccess(t *testing.T) {
-	msg, err := NewNativeMessage(`{"foo":"bar"}`, aTimestamp, publishRef, messageTypePartial)
+	msg, err := NewNativeMessage(`{"foo":"bar"}`, aTimestamp, publishRef, messageTypeContentPublished)
 	assert.NoError(t, err, "It should return an error in creating a new message")
 	msg.AddHashHeader(aHash)
 
@@ -464,6 +514,6 @@ func TestBuildNativeMessageSuccess(t *testing.T) {
 }
 
 func TestBuildNativeMessageFailure(t *testing.T) {
-	_, err := NewNativeMessage("__INVALID_BODY__", aTimestamp, publishRef, messageTypePartial)
+	_, err := NewNativeMessage("__INVALID_BODY__", aTimestamp, publishRef, messageTypeContentPublished)
 	assert.EqualError(t, err, "invalid character '_' looking for beginning of value", "It should return an error in creating a new message")
 }

--- a/native/native_writer_test.go
+++ b/native/native_writer_test.go
@@ -17,8 +17,7 @@ import (
 var methodeCollection = []string{"methode"}
 
 const (
-	methodeOriginSystemID = "http://cmdb.ft.com/systems/methode-web-pub"
-
+	methodeOriginSystemID   = "http://cmdb.ft.com/systems/methode-web-pub"
 	publishRef              = "tid_test-pub-ref"
 	aUUID                   = "572d0acc-3f12-4e70-8830-8092c1042a52"
 	aTimestamp              = "2017-02-16T12:56:16Z"
@@ -261,12 +260,12 @@ func TestWriteMessageToCollectionWithSuccess(t *testing.T) {
 	nws := setupMockNativeWriterService(t, 200, withoutNativeHashHeader)
 	defer nws.Close()
 
-	msg, err := NewNativeMessage("{}", aTimestamp, publishRef)
+	msg, err := NewNativeMessage("{}", aTimestamp, publishRef, messageTypePartial)
 	msg.AddContentTypeHeader(aContentType)
 	assert.NoError(t, err, "It should not return an error by creating a message")
 
 	w := NewWriter(nws.URL, *testCollectionsOriginIdsMap, p)
-	contentUUID, err := w.WriteToCollection(msg, methodeCollection[0])
+	contentUUID, _, err := w.WriteToCollection(msg, methodeCollection[0])
 
 	assert.NoError(t, err, "It should not return an error")
 	assert.Equal(t, aUUID, contentUUID)
@@ -282,13 +281,13 @@ func TestWriteMessageWithHashToCollectionWithSuccess(t *testing.T) {
 	nws := setupMockNativeWriterService(t, 200, withNativeHashHeader)
 	defer nws.Close()
 
-	msg, err := NewNativeMessage("{}", aTimestamp, publishRef)
+	msg, err := NewNativeMessage("{}", aTimestamp, publishRef, messageTypePartial)
 	assert.NoError(t, err, "It should not return an error by creating a message")
 	msg.AddHashHeader(aHash)
 	msg.AddContentTypeHeader(aContentType)
 
 	w := NewWriter(nws.URL, *testCollectionsOriginIdsMap, p)
-	contentUUID, err := w.WriteToCollection(msg, methodeCollection[0])
+	contentUUID, _, err := w.WriteToCollection(msg, methodeCollection[0])
 
 	assert.NoError(t, err, "It should not return an error")
 	assert.Equal(t, aUUID, contentUUID)
@@ -304,13 +303,13 @@ func TestWriteMessageToCollectionWithContentTypeSuccess(t *testing.T) {
 	nws := setupMockNativeWriterService(t, 200, withNativeHashHeader)
 	defer nws.Close()
 
-	msg, err := NewNativeMessage("{}", aTimestamp, publishRef)
+	msg, err := NewNativeMessage("{}", aTimestamp, publishRef, messageTypePartial)
 	assert.NoError(t, err, "It should not return an error by creating a message")
 	msg.AddHashHeader(aHash)
 	msg.AddContentTypeHeader(aContentType)
 
 	w := NewWriter(nws.URL, *testCollectionsOriginIdsMap, p)
-	contentUUID, err := w.WriteToCollection(msg, methodeCollection[0])
+	contentUUID, _, err := w.WriteToCollection(msg, methodeCollection[0])
 
 	assert.NoError(t, err, "It should not return an error")
 	assert.Equal(t, aUUID, contentUUID)
@@ -326,12 +325,12 @@ func TestWriteContentBodyToCollectionFailBecauseOfMissingUUID(t *testing.T) {
 	nws := setupMockNativeWriterService(t, 200, withNativeHashHeader)
 	defer nws.Close()
 
-	msg, err := NewNativeMessage("{}", aTimestamp, publishRef)
+	msg, err := NewNativeMessage("{}", aTimestamp, publishRef, messageTypePartial)
 	assert.NoError(t, err, "It should not return an error by creating a message")
 	msg.AddHashHeader(aHash)
 
 	w := NewWriter(nws.URL, *testCollectionsOriginIdsMap, p)
-	_, err = w.WriteToCollection(msg, methodeCollection[0])
+	_, _, err = w.WriteToCollection(msg, methodeCollection[0])
 
 	assert.EqualError(t, err, "UUID not found", "It should return a  UUID not found error")
 	p.AssertExpectations(t)
@@ -346,13 +345,13 @@ func TestWriteContentBodyToCollectionFailBecauseOfNativeRWServiceInternalError(t
 	nws := setupMockNativeWriterService(t, 500, withoutNativeHashHeader)
 	defer nws.Close()
 
-	msg, err := NewNativeMessage("{}", aTimestamp, publishRef)
+	msg, err := NewNativeMessage("{}", aTimestamp, publishRef, messageTypePartial)
 	assert.NoError(t, err, "It should not return an error by creating a message")
 	msg.AddHashHeader(aHash)
 	msg.AddContentTypeHeader(aContentType)
 
 	w := NewWriter(nws.URL, *testCollectionsOriginIdsMap, p)
-	_, err = w.WriteToCollection(msg, methodeCollection[0])
+	_, _, err = w.WriteToCollection(msg, methodeCollection[0])
 
 	assert.EqualError(t, err, "Native writer returned non-200 code", "It should return a non-200 HTTP status error")
 	p.AssertExpectations(t)
@@ -365,13 +364,13 @@ func TestWriteContentBodyToCollectionFailBecauseOfNativeRWServiceNotAvailable(t 
 
 	p.On("getUUID", aContentBody).Return(aUUID, nil)
 
-	msg, err := NewNativeMessage("{}", aTimestamp, publishRef)
+	msg, err := NewNativeMessage("{}", aTimestamp, publishRef, messageTypePartial)
 	assert.NoError(t, err, "It should not return an error by creating a message")
 	msg.AddHashHeader(aHash)
 	msg.AddContentTypeHeader(aContentType)
 
 	w := NewWriter("http://an-address.com", *testCollectionsOriginIdsMap, p)
-	_, err = w.WriteToCollection(msg, methodeCollection[0])
+	_, _, err = w.WriteToCollection(msg, methodeCollection[0])
 
 	assert.Error(t, err, "It should return an error")
 	p.AssertExpectations(t)
@@ -453,7 +452,7 @@ func (p *ContentBodyParserMock) getUUID(body map[string]interface{}) (string, er
 }
 
 func TestBuildNativeMessageSuccess(t *testing.T) {
-	msg, err := NewNativeMessage(`{"foo":"bar"}`, aTimestamp, publishRef)
+	msg, err := NewNativeMessage(`{"foo":"bar"}`, aTimestamp, publishRef, messageTypePartial)
 	assert.NoError(t, err, "It should return an error in creating a new message")
 	msg.AddHashHeader(aHash)
 
@@ -465,6 +464,6 @@ func TestBuildNativeMessageSuccess(t *testing.T) {
 }
 
 func TestBuildNativeMessageFailure(t *testing.T) {
-	_, err := NewNativeMessage("__INVALID_BODY__", aTimestamp, publishRef)
+	_, err := NewNativeMessage("__INVALID_BODY__", aTimestamp, publishRef, messageTypePartial)
 	assert.EqualError(t, err, "invalid character '_' looking for beginning of value", "It should return an error in creating a new message")
 }

--- a/queue/message_handler_test.go
+++ b/queue/message_handler_test.go
@@ -41,7 +41,7 @@ func init() {
 func TestWriteToNativeSuccessfullyWithoutForward(t *testing.T) {
 	w := new(mocks.WriterMock)
 	w.On("GetCollection", methodeOriginSystemID, contentType).Return(methodeCollection, nil)
-	w.On("WriteToCollection", mock.AnythingOfType("native.NativeMessage"), methodeCollection).Return("", nil)
+	w.On("WriteToCollection", mock.AnythingOfType("native.NativeMessage"), methodeCollection).Return("", "", nil)
 
 	p := new(mocks.ProducerMock)
 
@@ -56,7 +56,7 @@ func TestWriteToNativeSuccessfullyWithoutForward(t *testing.T) {
 func TestWriteToNativeSuccessfullyWithForward(t *testing.T) {
 	w := new(mocks.WriterMock)
 	w.On("GetCollection", methodeOriginSystemID, contentType).Return(methodeCollection, nil)
-	w.On("WriteToCollection", mock.AnythingOfType("native.NativeMessage"), methodeCollection).Return("", nil)
+	w.On("WriteToCollection", mock.AnythingOfType("native.NativeMessage"), methodeCollection).Return("", "", nil)
 
 	p := new(mocks.ProducerMock)
 	p.On("SendMessage", mock.AnythingOfType("kafka.FTMessage")).Return(nil)
@@ -99,7 +99,7 @@ func TestWriteToNativeFailWithNotCollectionForOriginId(t *testing.T) {
 func TestWriteToNativeFailBecauseOfWriter(t *testing.T) {
 	w := new(mocks.WriterMock)
 	w.On("GetCollection", methodeOriginSystemID, contentType).Return(methodeCollection, nil)
-	w.On("WriteToCollection", mock.AnythingOfType("native.NativeMessage"), methodeCollection).Return("", errors.New("I do not want to write today!"))
+	w.On("WriteToCollection", mock.AnythingOfType("native.NativeMessage"), methodeCollection).Return("", "", errors.New("I do not want to write today!"))
 
 	p := new(mocks.ProducerMock)
 
@@ -115,7 +115,7 @@ func TestForwardFailBecauseOfProducer(t *testing.T) {
 	hook := logger.NewTestHook("native-ingester")
 	w := new(mocks.WriterMock)
 	w.On("GetCollection", methodeOriginSystemID, contentType).Return(methodeCollection, nil)
-	w.On("WriteToCollection", mock.AnythingOfType("native.NativeMessage"), methodeCollection).Return("", nil)
+	w.On("WriteToCollection", mock.AnythingOfType("native.NativeMessage"), methodeCollection).Return("", "", nil)
 
 	p := new(mocks.ProducerMock)
 	p.On("SendMessage", mock.AnythingOfType("kafka.FTMessage")).Return(errors.New("Today, I am not writing on a queue."))

--- a/queue/publication_event.go
+++ b/queue/publication_event.go
@@ -25,6 +25,10 @@ func (pe *publicationEvent) contentType() string {
 	return strings.TrimSpace(pe.Headers["Content-Type"])
 }
 
+func (pe *publicationEvent) messageType() string {
+	return strings.TrimSpace(pe.Headers["Message-Type"])
+}
+
 func (pe *publicationEvent) nativeMessage() (native.NativeMessage, error) {
 
 	timestamp, found := pe.Headers["Message-Timestamp"]
@@ -32,7 +36,7 @@ func (pe *publicationEvent) nativeMessage() (native.NativeMessage, error) {
 		return native.NativeMessage{}, errors.New("publish event does not contain timestamp")
 	}
 
-	msg, err := native.NewNativeMessage(pe.Body, timestamp, pe.transactionID())
+	msg, err := native.NewNativeMessage(pe.Body, timestamp, pe.transactionID(), pe.messageType())
 
 	if err != nil {
 		return native.NativeMessage{}, err


### PR DESCRIPTION
## What?
Added functionality to process Kafka messages for partial updates for Spark publishing (messages that have `Message-Type: cms-partial-content-published`
## Why?
So that we can support `PATCH` updates.
## Anything, in particular, you'd like to highlight to reviewers?
The rule which triggers partial updates is defined in `native_writer.go` lines `68-70`. It basically means that if the message has the `partial` message-type and is intended for the `universal-content` collection, then it is eligible for a partial update. 
@gotha please let me know if this rule is incorrect or incomplete.

If the partial header is present, but the collection is not `universal-content`, then an error is thrown.
## Scope and particulars of this PR (Please tick all that apply)
-   [ ] Tech hygiene (dependency updating & other tech debt)
-   [ ] Bug fix
-   [x] Feature
-   [ ] Documentation / Runbook update
-   [ ] Breaking change
-   [ ] Minor change (e.g. fixing a typo, adding config)
-   [ ] Review not required
## Checklist for **reviewers** (Please tick all that apply)
-   [ ] Would a face-to-face review work better for this PR (Check if you feel you don't fully understand the PR)?
-   [ ] Has the documentation been updated?