### PR TITLE
Add native metadata ingester runbook

### DIFF
--- a/.github/runbooks.yml
+++ b/.github/runbooks.yml
@@ -35,4 +35,5 @@ runbooks:
   # runbook.md tries to parse the system code from the runbook's filename (format: my-sys-code_runbook.md)
   systemCodes:
     # paths are relative to root, omitting ./ (case-insensitive)
-    native-ingester: runbooks/runbook.md
+    native-ingester: runbooks/native-ingester_runbook.md
+    native-ingester-metadata: runbooks/native-ingester-metadata_runbook.md

--- a/runbooks/native-ingester-metadata_runbook.md
+++ b/runbooks/native-ingester-metadata_runbook.md
@@ -1,0 +1,121 @@
+# UPP - Native Metadata Ingester
+
+The Native Metadata ingester consumes messages from a Kafka topic and propagates them to be written by the read-write service in the Native store.
+
+## Primary URL
+
+<https://upp-prod-publish-glb.upp.ft.com/__native-ingester-metadata/>
+
+## Service Tier
+
+Platinum
+
+## Lifecycle Stage
+
+Production
+
+## Delivered By
+
+content
+
+## Supported By
+
+content
+
+## Known About By
+
+- hristo.georgiev
+- robert.marinov
+- elina.kaneva
+- tsvetan.dimitrov
+- elitsa.pavlova
+- ivan.nikolov
+- miroslav.gatsanoga
+- kalin.arsov
+- mihail.mihaylov
+- dimitar.terziev
+
+## Host Platform
+
+AWS
+
+## Architecture
+
+The Native Metadata Ingester consumes messages containing native CMS metadata from the "PreNativeCmsMetadataPublicationEvents" Kafka topic. According to the data source, it sends the metadata to be written to a specific DB collection. Optionally, it forwards consumed messages to a different queue.
+
+## Contains Personal Data
+
+No
+
+## Contains Sensitive Data
+
+No
+
+## Dependencies
+
+- nativestorereaderwriter
+- upp-kafka
+- upp-zookeeper
+
+## Failover Architecture Type
+
+ActivePassive
+
+## Failover Process Type
+
+FullyAutomated
+
+## Failback Process Type
+
+FullyAutomated
+
+## Failover Details
+
+The service is deployed in both publishing clusters. The failover guide for the cluster is located here:
+<https://github.com/Financial-Times/upp-docs/tree/master/failover-guides/publishing-cluster>
+
+## Data Recovery Process Type
+
+NotApplicable
+
+## Data Recovery Details
+
+The service does not store data, so it does not require any data recovery steps.
+
+## Release Process Type
+
+PartiallyAutomated
+
+## Rollback Process Type
+
+Manual
+
+## Release Details
+
+Manual failover is needed when a new version of the service is deployed to production. Otherwise, an automated failover is going to take place when releasing.
+For more details about the failover process please see: <https://github.com/Financial-Times/upp-docs/tree/master/failover-guides/publishing-cluster>
+
+## Key Management Process Type
+
+Manual
+
+## Key Management Details
+
+To access the service clients need to provide basic auth credentials.
+To rotate credentials you need to login to a particular cluster and update varnish-auth secrets.
+
+## Monitoring
+
+Publishing EU health:
+- <https://upp-prod-publish-eu.upp.ft.com/__health/__pods-health?service-name=native-ingester-metadata>
+
+Publishing US health:
+- <https://upp-prod-publish-us.upp.ft.com/__health/__pods-health?service-name=native-ingester-metadata>
+
+## First Line Troubleshooting
+
+<https://github.com/Financial-Times/upp-docs/tree/master/guides/ops/first-line-troubleshooting>
+
+## Second Line Troubleshooting
+
+Please refer to the GitHub repository README for troubleshooting information.

--- a/runbooks/native-ingester_runbook.md
+++ b/runbooks/native-ingester_runbook.md
@@ -1,14 +1,10 @@
 # UPP - Native Ingester
 
-Native ingester consumes messages from a Kafka topic (both content and metadata flows) and propagates them to be written by read-write services in Native store accoridngly.
-
-## Code
-
-native-ingester
+The Native ingester consumes messages from a Kafka topic and propagates them to be written by the read-write service in the Native store.
 
 ## Primary URL
 
-https://upp-prod-publishing-glb.upp.ft.com/__native-ingester/
+<https://upp-prod-publish-glb.upp.ft.com/__native-ingester-cms/>
 
 ## Service Tier
 
@@ -45,7 +41,7 @@ AWS
 
 ## Architecture
 
-Native ingester consumes messages containing native CMS content or native CMS metadata from ONE queue topic. According to the data source, native ingester sends the content or metadata to be written to a specific db collection. Optionally, it forwards consumed messages to a different queue.
+The Native Ingester consumes messages containing native CMS content from the "PreNativeCmsPublicationEvents" Kafka topic. According to the data source, it sends the content to be written to a specific DB collection. Optionally, it forwards consumed messages to a different queue.
 
 ## Contains Personal Data
 
@@ -57,8 +53,9 @@ No
 
 ## Dependencies
 
-- upp-kafka
 - nativestorereaderwriter
+- upp-kafka
+- upp-zookeeper
 
 ## Failover Architecture Type
 
@@ -75,7 +72,7 @@ FullyAutomated
 ## Failover Details
 
 The service is deployed in both publishing clusters. The failover guide for the cluster is located here:
-https://github.com/Financial-Times/upp-docs/tree/master/failover-guides/publishing-cluster
+<https://github.com/Financial-Times/upp-docs/tree/master/failover-guides/publishing-cluster>
 
 ## Data Recovery Process Type
 
@@ -96,7 +93,7 @@ Manual
 ## Release Details
 
 Manual failover is needed when a new version of the service is deployed to production. Otherwise, an automated failover is going to take place when releasing.
-For more details about the failover process please see: https://github.com/Financial-Times/upp-docs/tree/master/failover-guides/publishing-cluster
+For more details about the failover process please see: <https://github.com/Financial-Times/upp-docs/tree/master/failover-guides/publishing-cluster>
 
 ## Key Management Process Type
 
@@ -109,16 +106,15 @@ To rotate credentials you need to login to a particular cluster and update varni
 
 ## Monitoring
 
-- Pub-Prod-EU health:
-https://upp-prod-publish-eu.upp.ft.com/__health/__pods-health?service-name=native-ingester-cms
-https://upp-prod-publish-eu.upp.ft.com/__health/__pods-health?service-name=native-ingester-metadata
-- Pub-Prod-US health:
-https://upp-prod-publish-us.upp.ft.com/__health/__pods-health?service-name=native-ingester-cms
-https://upp-prod-publish-us.upp.ft.com/__health/__pods-health?service-name=native-ingester-metadata
+Publishing EU health:
+- <https://upp-prod-publish-eu.upp.ft.com/__health/__pods-health?service-name=native-ingester-cms>
+
+Publishing US health:
+- <https://upp-prod-publish-us.upp.ft.com/__health/__pods-health?service-name=native-ingester-cms>
 
 ## First Line Troubleshooting
 
-https://github.com/Financial-Times/upp-docs/tree/master/guides/ops/first-line-troubleshooting
+<https://github.com/Financial-Times/upp-docs/tree/master/guides/ops/first-line-troubleshooting>
 
 ## Second Line Troubleshooting
 


### PR DESCRIPTION
# Description

## What

Add native metadata ingester runbook

## Why

JIRA ticket UPPSF-1181

## Anything, in particular, you'd like to highlight to reviewers

It seems that the metadata ingester was accidentally skipped when the runbooks for this repo were added so I've added the missing runbook (mostly copy-paste).
I've also added some minor fixes needed for the other runbook.

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [ ] Feature
- [x] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
