### PR TITLE
Remove v1-metadata form config_metadata.json

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"errors"
+	"sort"
 	"strings"
 	"testing"
 )
@@ -11,8 +12,14 @@ func toString(c *Configuration) string {
 		return ""
 	}
 	var str string
-	for oKey, origCollection := range c.Config {
-		str += oKey
+	var keys []string
+	for key := range c.Config {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		origCollection := c.Config[key]
+		str += key
 		for _, val := range origCollection {
 			str += val.ContentType + val.Collection
 		}
@@ -321,9 +328,9 @@ func TestConfigurationMetadata_GetCollection(t *testing.T) {
 	}
 	c := &Configuration{
 		Config: map[string][]OriginSystemConfig{
-			"http://cmdb.ft.com/systems/methode-web-pub": {
+			"http://cmdb.ft.com/systems/pac": {
 				{ContentType: ".*",
-					Collection: "v1-metadata",
+					Collection: "pac-metadata",
 				},
 			},
 			"http://cmdb.ft.com/systems/next-video-editor": {
@@ -345,24 +352,24 @@ func TestConfigurationMetadata_GetCollection(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			"methode json",
-			args{"http://cmdb.ft.com/systems/methode-web-pub",
+			"pac json",
+			args{"http://cmdb.ft.com/systems/pac",
 				"application/json"},
-			"v1-metadata",
+			"pac-metadata",
 			false,
 		},
 		{
 			"methode null CT",
-			args{"http://cmdb.ft.com/systems/methode-web-pub",
+			args{"http://cmdb.ft.com/systems/pac",
 				""},
-			"v1-metadata",
+			"pac-metadata",
 			false,
 		},
 		{
 			"methode",
-			args{"http://cmdb.ft.com/systems/methode-web-pub",
+			args{"http://cmdb.ft.com/systems/pac",
 				"anytype"},
-			"v1-metadata",
+			"pac-metadata",
 			false,
 		},
 		{

--- a/config_metadata.json
+++ b/config_metadata.json
@@ -1,10 +1,4 @@
 {
-    "http://cmdb.ft.com/systems/methode-web-pub": [
-        {
-            "content_type": ".*",
-            "collection": "v1-metadata"
-        }
-    ],
     "http://cmdb.ft.com/systems/pac": [
         {
             "content_type": ".*",

--- a/queue/message_handler.go
+++ b/queue/message_handler.go
@@ -40,7 +40,7 @@ func (mh *MessageHandler) HandleMessage(msg kafka.FTMessage) error {
 		logger.NewMonitoringEntry("Ingest", pubEvent.transactionID(), mh.contentType).
 			WithValidFlag(false).
 			Warn(fmt.Sprintf("Skipping content because of not whitelisted combination (Origin-System-Id, Content-Type): (%s, %s)", pubEvent.originSystemID(), writerMsg.ContentType()))
-		return err
+		return nil
 	}
 
 	contentUUID, updatedContent, writerErr := mh.writer.WriteToCollection(writerMsg, collection)


### PR DESCRIPTION
# Description

## What

Removed `v1-metadata` from `config_metadata.json` and updated the tests which were using `v1-metadata` value.
Also updated the `toString` method in `config_test.go` because the tests were failing sometimes since `toString` method interated over a map.

## Why

[JIRA](https://financialtimes.atlassian.net/browse/UPPSF-2375)

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
