### PR TITLE
Allow pages ingestion by cct, spark and spark-lists origins

### DIFF
--- a/config.json
+++ b/config.json
@@ -23,11 +23,19 @@
     ],
     "http://cmdb.ft.com/systems/cct": [
         {
+            "content_type": "^(application/)*(vnd.ft-upp-page).*$",
+            "collection": "pages"
+        },
+        {
             "content_type": ".*",
             "collection": "universal-content"
         }
     ],
     "http://cmdb.ft.com/systems/spark": [
+        {
+            "content_type": "^(application/)*(vnd.ft-upp-page).*$",
+            "collection": "pages"
+        },
         {
             "content_type": ".*",
             "collection": "universal-content"
@@ -37,6 +45,10 @@
         {
             "content_type": "^(application/)*(vnd.ft-upp-list).*$",
             "collection": "universal-content"
+        },
+        {
+            "content_type": "^(application/)*(vnd.ft-upp-page).*$",
+            "collection": "pages"
         }
     ]
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -166,6 +166,10 @@ func TestConfiguration_GetCollection(t *testing.T) {
 				},
 			},
 			"http://cmdb.ft.com/systems/cct": {
+				{
+					ContentType: "^(application/)*(vnd.ft-upp-page).*$",
+					Collection:  "pages",
+				},
 				{ContentType: ".*",
 					Collection: "universal-content",
 				},
@@ -178,6 +182,10 @@ func TestConfiguration_GetCollection(t *testing.T) {
 			"http://cmdb.ft.com/systems/spark-lists": {
 				{ContentType: "^(application/)*(vnd.ft-upp-list\\+json).*$",
 					Collection: "universal-content",
+				},
+				{
+					ContentType: "^(application/)*(vnd.ft-upp-page).*$",
+					Collection:  "pages",
 				},
 			},
 		},
@@ -278,6 +286,15 @@ func TestConfiguration_GetCollection(t *testing.T) {
 			false,
 		},
 		{
+			"cct page OK",
+			args{
+				originID:    "http://cmdb.ft.com/systems/cct",
+				contentType: "application/vnd.ft-upp-page+json",
+			},
+			"pages",
+			false,
+		},
+		{
 			"spark article OK",
 			args{"http://cmdb.ft.com/systems/spark",
 				"application/vnd.ft-upp-article+json"},
@@ -288,6 +305,15 @@ func TestConfiguration_GetCollection(t *testing.T) {
 			"spark list OK",
 			args{"http://cmdb.ft.com/systems/spark",
 				"application/vnd.ft-upp-list+json"},
+			"universal-content",
+			false,
+		},
+		{
+			"spark page OK",
+			args{
+				originID:    "http://cmdb.ft.com/systems/spark",
+				contentType: "application/vnd-ft.upp-page+json",
+			},
 			"universal-content",
 			false,
 		},
@@ -304,6 +330,15 @@ func TestConfiguration_GetCollection(t *testing.T) {
 				"application/vnd.ft-upp-article+json"},
 			"",
 			true,
+		},
+		{
+			"spark-lists page OK",
+			args{
+				originID:    "http://cmdb.ft.com/systems/spark-lists",
+				contentType: "application/vnd.ft-upp-page+json",
+			},
+			"pages",
+			false,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
# Description

## What

Allows pages to be published from the `spark-lists` origin and stored to the respective native store collection.

## Why

[JIRA Ticket](https://financialtimes.atlassian.net/browse/UPPSF-2523)

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
