### PR TITLE
Adding community origin for live events.

### DIFF
--- a/config.json
+++ b/config.json
@@ -50,5 +50,11 @@
             "content_type": "^(application/)*(vnd.ft-upp-page).*$",
             "collection": "pages"
         }
+    ],
+    "http://cmdb.ft.com/systems/cle": [
+        {
+            "content_type": "^(application/)*(vnd.ft-upp-live-event).*$",
+            "collection": "universal-content"
+        }
     ]
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -188,6 +188,12 @@ func TestConfiguration_GetCollection(t *testing.T) {
 					Collection:  "pages",
 				},
 			},
+			"http://cmdb.ft.com/systems/cle": {
+				{
+					ContentType: "^(application/)*(vnd.ft-upp-live-event).*$",
+					Collection:  "universal-content",
+				},
+			},
 		},
 	}
 	err := c.validateConfig()
@@ -339,6 +345,29 @@ func TestConfiguration_GetCollection(t *testing.T) {
 			},
 			"pages",
 			false,
+		},
+		{
+			"Community live event OK",
+			args{"http://cmdb.ft.com/systems/cle",
+				"application/vnd.ft-upp-live-event+json"},
+			"universal-content",
+			false,
+		},
+		{
+			"Community live event wrong CT",
+			args{"http://cmdb.ft.com/systems/cle",
+				"application/vnd.ft-upp-list+json"},
+			"",
+			true,
+		},
+		{
+			"Community live event wrong origin",
+			args{
+				originID:    "http://cmdb.ft.com/systems/community-event",
+				contentType: "application/vnd-ft.upp-live-event+json",
+			},
+			"",
+			true,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
# Description

## What

Adding the new origin and content type to allow them to be ingested by the native-ingester.

## Why

[JIRA ticket](https://financialtimes.atlassian.net/browse/UPPSF-2862)

## Anything, in particular, you'd like to highlight to reviewers

The source, meaning the `X-Origin-Id` has to be decided by our team and we are not committed 100% on `community` just yet. If a better suggestion is brought up it will be changed, otherwise this will remain. 

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
