### PR TITLE
Fix kafka connectivity timeouts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/Financial-Times/go-fthealth v0.0.0-20171204124831-1b007e2b37b7
 	github.com/Financial-Times/go-logger/v2 v2.0.1
-	github.com/Financial-Times/kafka-client-go/v4 v4.1.1
+	github.com/Financial-Times/kafka-client-go/v4 v4.2.0
 	github.com/Financial-Times/service-status-go v0.2.0
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/mux v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/Financial-Times/go-fthealth v0.0.0-20171204124831-1b007e2b37b7 h1:dkf
 github.com/Financial-Times/go-fthealth v0.0.0-20171204124831-1b007e2b37b7/go.mod h1:gpAzq6W5rCheYlY32JOIxS/VjVcYHbC2PkMzQngHT9c=
 github.com/Financial-Times/go-logger/v2 v2.0.1 h1:iekEfSsUtlkg+YkXTZo+/fIN2VbZ2/3Hl9yolP3z5X8=
 github.com/Financial-Times/go-logger/v2 v2.0.1/go.mod h1:Jpky5JYSX7xjGUClfA9hEMDmn40tUbfQQITjVIFGQiM=
-github.com/Financial-Times/kafka-client-go/v4 v4.1.1 h1:RqbRid3BUu6Q2i9GPxSjg968Bz618KZWZbUIKBA+Dnw=
-github.com/Financial-Times/kafka-client-go/v4 v4.1.1/go.mod h1:iBrIC0yvFjjCqqfJjVsKpOk92lJInQbOpUrsLtp9SwY=
+github.com/Financial-Times/kafka-client-go/v4 v4.2.0 h1:ssnxmlubtkvaiFm3LixG+12NbwegHCI9/yMlZ7ROvr8=
+github.com/Financial-Times/kafka-client-go/v4 v4.2.0/go.mod h1:iBrIC0yvFjjCqqfJjVsKpOk92lJInQbOpUrsLtp9SwY=
 github.com/Financial-Times/service-status-go v0.2.0 h1:ajT52zmCj0Ih4bq2zWsWOnMY4rbryWwg1EW63RWVKp8=
 github.com/Financial-Times/service-status-go v0.2.0/go.mod h1:eab7/Pnkftoni5XXKTUeXDUH7832uczOyGUPSwfVXNM=
 github.com/Shopify/sarama v1.38.1 h1:lqqPUPQZ7zPqYlWpTh+LQ9bhYNu2xJL6k1SJN4WVe2A=


### PR DESCRIPTION
# Description

## What

Upgrades to the latest version of `kafka-client-go` which introduces additional timeout if a connectivity check is hanging due to an inactive Kafka broker.

## Why

[JIRA Ticket](https://financialtimes.atlassian.net/browse/UPPSF-4249)

## Anything, in particular, you'd like to highlight to reviewers

## Scope and particulars of this PR (Please tick all that apply)

- [x] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

## DoD - Ensure all relevant tasks are completed before marking this PR as "Ready for review"

- [x] Test coverage is not significantly decreased
- [x] All PR checks have passed
- [x] Changes are deployed on dev before asking for review
- [x] Documentations remains up-to-date
  - [ ] OpenAPI definition file is updated
  - [ ] README file is updated
  - [ ] Documentation is updated in upp-docs and upp-public-docs
  - [ ] Architecture diagrams are updated

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
