### PR TITLE
Allow `cct` also for content relations, currently is only `spark`

### DIFF
--- a/config.json
+++ b/config.json
@@ -15,6 +15,10 @@
             "collection": "pages"
         },
         {
+            "content_type": "^(application/)*(vnd.ft-upp-content-relation).*$",
+            "collection": "content-relation"
+        },
+        {
             "content_type": ".*",
             "collection": "universal-content"
         }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -165,6 +165,10 @@ func TestConfiguration_GetCollection(t *testing.T) {
 					ContentType: "^(application/)*(vnd.ft-upp-page).*$",
 					Collection:  "pages",
 				},
+				{
+					ContentType: "^(application/)*(vnd.ft-upp-content-relation\\+json).*$",
+					Collection:  "content-relation",
+				},
 				{ContentType: ".*",
 					Collection: "universal-content",
 				},
@@ -406,6 +410,13 @@ func TestConfiguration_GetCollection(t *testing.T) {
 		{
 			"ContentRelation OK",
 			args{"http://cmdb.ft.com/systems/spark",
+				"application/vnd.ft-upp-content-relation+json"},
+			"content-relation",
+			false,
+		},
+		{
+			"ContentRelation OK",
+			args{"http://cmdb.ft.com/systems/cct",
 				"application/vnd.ft-upp-content-relation+json"},
 			"content-relation",
 			false,


### PR DESCRIPTION
# Description

Allow `cct` also for content relations, currently is only `spark`

## Why
We want to enable cct as well because of spark requirement

## Anything, in particular, you'd like to highlight to reviewers

Mention here sections of code which you would like reviewers to pay extra attention to .E.g

_Would appreciate a second pair of eyes on the test_  
_I am not quite sure how this bit works_  
_Is there a better library for doing x_  

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

## DoD - Ensure all relevant tasks are completed before marking this PR as "Ready for review"

- [ ] Test coverage is not significantly decreased
- [ ] All PR checks have passed
- [ ] Changes are deployed on dev before asking for review
- [ ] Documentations remains up-to-date
- [ ] OpenAPI definition file is updated
- [ ] README file is updated
- [ ] Documentation is updated in upp-docs and upp-public-docs
- [ ] Architecture diagrams are updated

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
